### PR TITLE
Fixes #6

### DIFF
--- a/css/product.css
+++ b/css/product.css
@@ -38,6 +38,11 @@
 	box-shadow: 0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22);;
 }
 
+/* Limit the width of images inside product-detail item to make them all the same size */
+.product-detail > img {
+  width: 75%;
+}
+
 .product-detail:first-child
 {
 	margin-left: 0%;


### PR DESCRIPTION
The images inside the product-detail category need to have a set width so they don't resize to fit the container based on their own original sizes. 

Please see screenshot below for the fixed version.

![screencapture-192-168-1-114-8080-product-html-1508418971935](https://user-images.githubusercontent.com/6593585/31772765-5883e96c-b4e9-11e7-89d8-16f8ba65b1f6.png)

You can give the images a specific class (e.g. product-detail__image) to make it cleaner, or change the width to whatever else you want to test.